### PR TITLE
Reduce Duplication in GitHub Actions

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -3,11 +3,12 @@ on: [push, pull_request]
 jobs:
   # This project is intended to be run locally. We don't know what computer the 
   # maintainer will have, so run the tests on common OS.
-  run-tests-linux:
-    runs-on: ubuntu-latest
+  run-tests:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ['3.8.5', '3.9']
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -20,38 +21,3 @@ jobs:
           CENSUS_KEY: ${{ secrets.CENSUS_KEY }}
           FIREBASE_SERVICE_KEY: ${{ secrets.FIREBASE_SERVICE_KEY }}
       - run: flake8
-  run-tests-windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: ['3.8.5', '3.9']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: py -m pip install --upgrade pip
-      - run: pip install -r requirements.txt
-      - run: pytest
-        env:
-          CENSUS_KEY: ${{ secrets.CENSUS_KEY }}
-          FIREBASE_SERVICE_KEY: ${{ secrets.FIREBASE_SERVICE_KEY }}
-      - run: flake8
-  run-tests-mac-os:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: ['3.8.5', '3.9']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: python3 -m pip install --upgrade pip
-      - run: pip install -r requirements.txt
-      - run: pytest
-        env:
-          CENSUS_KEY: ${{ secrets.CENSUS_KEY }}
-          FIREBASE_SERVICE_KEY: ${{ secrets.FIREBASE_SERVICE_KEY }}
-      - run: flake8
-


### PR DESCRIPTION
Change from duplicate jobs to one job with a matrix for the operating systems. This will make it easier to make any changes to the actions since we'll only have to change one place instead of three. See docs here: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-running-with-more-than-one-operating-system