### PR TITLE
Add Helpful Message to Cover Common Cause of "Expected BOF record" Error During file_to_json()

### DIFF
--- a/src/file_to_json.py
+++ b/src/file_to_json.py
@@ -1,7 +1,6 @@
 import os
-import sys
-sys.path.append(os.path.abspath(''))
-import pandas as pd  # noqa: E402
+import xlrd
+import pandas as pd
 
 
 def file_to_json(input_dir, output_dir, blacklist=[]):
@@ -28,7 +27,11 @@ def file_to_json(input_dir, output_dir, blacklist=[]):
                     engine = 'openpyxl'
                 else:
                     engine = 'xlrd'
-                table = pd.read_excel(fp, sheet_name=None, engine=engine)
+                try:
+                    table = pd.read_excel(fp, sheet_name=None, engine=engine)
+                except xlrd.biffh.XLRDError as e:
+                    print(e)
+                    raise Exception("Error reading {0}. Close the file if you have it open.".format(fp))  # noqa: E501
                 if type(table) == dict:
                     for k in table:
                         if k not in blacklist:


### PR DESCRIPTION
If you have the food insecurity xlsx file open while running file_to_json(), it will raise this exception:

xlrd.biffh.XLRDError: Unsupported format, or corrupt file: Expected BOF record; found b',<your computer name>/'

I was able to figure out the cause from: https://stackoverflow.com/a/36752967

-Add a helpful message instead of just the cryptic message because I think opening the file will be the most likely cause of this exception. This does raise an exception during exception handling which causes a lot of logging, but it's an easy way to abort the program, print the original exception and have the helpful message at the bottom.
-Remove the line that added to sys.path since we don't need it in this file