### PR TITLE
Make wic data available to frontend add test

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -6,6 +6,7 @@ jobs:
   run-tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8.5', '3.9']
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/src/census_response.py
+++ b/src/census_response.py
@@ -315,7 +315,7 @@ class CensusData:
             # prevents conflicts with new columns
             # race_values = tuple(cls.data_metrics['race'].values())
             race_values = cls.get_data_values('race')
-            race_df = geo_df.loc[:, race_values]
+            race_df = geo_df.reindex(race_values, axis="columns")
 
             # divides df by race_total column to calculate percentages
             race_percent_df, pct_dict_series = nest_percentages(race_df, 'race_total')  # noqa: E501

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,5 @@
+import src.main
+
+
+def test_run():
+    src.main.main()


### PR DESCRIPTION
- Added test to run the main script
- Github Actions raised an error that did not raise on my machine, fixed that with reindex()
- Set fail fast to false so we know errors occur in all os/versions
  - Since this adds time to the action, do we know if we can run the tests concurrently?