### PR TITLE
Error When Rerunning WIC #46

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ api_keys.py
 ### Data Files ###
 final_jsons/*.json
 shape_files/*.json
-*.csv
+final_jsons/*.csv
 *.xls
 *.xlsx
 *.pkl

--- a/src/wic.py
+++ b/src/wic.py
@@ -55,10 +55,10 @@ def read_wic_data(always_run: bool = False) -> WICParticipation:
             1,
             96)
 
-        participation.women.to_csv(women_output_csv_path, index=False)
-        participation.children.to_csv(children_output_csv_path, index=False)
-        participation.infants.to_csv(infants_output_csv_path, index=False)
-        participation.total.to_csv(total_output_csv_path, index=False)
+        participation.women.to_csv(women_output_csv_path)
+        participation.children.to_csv(children_output_csv_path)
+        participation.infants.to_csv(infants_output_csv_path)
+        participation.total.to_csv(total_output_csv_path)
         return participation
     else:
         return WICParticipation(

--- a/tests/resources/wic_participation.csv
+++ b/tests/resources/wic_participation.csv
@@ -1,0 +1,2 @@
+NAME,race_amer_indian_or_alaskan_native,race_asian,race_black,race_native_hawaii_or_pacific_islander,race_white,race_multiracial,total,hispanic_or_latino
+ADAMS,3,1,97,3,322,51,365,20

--- a/tests/resources/wic_participation.csv
+++ b/tests/resources/wic_participation.csv
@@ -1,2 +1,2 @@
-NAME,race_amer_indian_or_alaskan_native,race_asian,race_black,race_native_hawaii_or_pacific_islander,race_white,race_multiracial,total,hispanic_or_latino
-ADAMS,3,1,97,3,322,51,365,20
+fips,NAME,race_amer_indian_or_alaskan_native,race_asian,race_black,race_native_hawaii_or_pacific_islander,race_white,race_multiracial,total,hispanic_or_latino
+17001,ADAMS,3,1,97,3,322,51,365,20

--- a/tests/test_wic.py
+++ b/tests/test_wic.py
@@ -44,3 +44,7 @@ def test_merge_wic():
 
     with open("tests/resources/df_merged_with_wic_expected.json") as expected_output:  # noqa: E501
         assert json_str == expected_output.read()
+
+
+def test_read_csv():
+    dataframe = wic.read_csv("tests/resources/wic_participation.csv")


### PR DESCRIPTION
We were passing Index=false when writing the CSV files which omits the index column, but we need the index column when we read the data.

